### PR TITLE
Missing tooltip block in lineplusbarchart.html

### DIFF
--- a/nvd3/templates/lineplusbarchart.html
+++ b/nvd3/templates/lineplusbarchart.html
@@ -24,6 +24,10 @@
     {{super()}}
     {% endblock axes %}
 
+    {% block tooltip %}
+    {{super()}}
+    {% endblock tooltip %}
+
     {% block legend %}
     {{super()}}
     {% endblock legend %}


### PR DESCRIPTION
Without this we cannot configure the the lineplusbar chart tooltips